### PR TITLE
support inplace *=, use ops.split

### DIFF
--- a/mindtorch/torch/_tensor.py
+++ b/mindtorch/torch/_tensor.py
@@ -209,3 +209,10 @@ def _float(self):
 
 Tensor.float = _float
 StubTensor.float = _float
+
+def __imul__(self, other):
+    self.copy_(self.mul(other))
+    return self
+
+Tensor.__imul__ = __imul__
+StubTensor.__imul__ = __imul__

--- a/mindtorch/torch/ops/array.py
+++ b/mindtorch/torch/ops/array.py
@@ -215,8 +215,9 @@ def scatter_update(input, indices, updates):
 # split
 has_split = hasattr(mindspore.mint, 'split')
 def split(tensor, split_size_or_sections, dim=0):
-    if use_pyboost() and has_split:
-        return mindspore.mint.split(tensor, split_size_or_sections, dim)
+    # FIXME: mint.split accuracy issue
+    # if use_pyboost() and has_split:
+    #     return mindspore.mint.split(tensor, split_size_or_sections, dim)
     return ops.split(tensor, split_size_or_sections, dim)
 
 # squeeze


### PR DESCRIPTION
- support inplace *=
- use ops.split, mint.split has accuracy issue