### PR TITLE
improve performance

### DIFF
--- a/mindtorch/torch/cuda/__init__.py
+++ b/mindtorch/torch/cuda/__init__.py
@@ -12,7 +12,7 @@ def manual_seed_all(seed: int):
     manual_seed(seed)
 
 def current_device():
-    return -1
+    return 'Ascend'
 
 def is_available():
     return True

--- a/mindtorch/torch/ops/array.py
+++ b/mindtorch/torch/ops/array.py
@@ -215,9 +215,8 @@ def scatter_update(input, indices, updates):
 # split
 has_split = hasattr(mindspore.mint, 'split')
 def split(tensor, split_size_or_sections, dim=0):
-    # FIXME: mint.split accuracy issue
-    # if use_pyboost() and has_split:
-    #     return mindspore.mint.split(tensor, split_size_or_sections, dim)
+    if use_pyboost() and has_split:
+        return mindspore.mint.split(tensor, split_size_or_sections, dim)
     return ops.split(tensor, split_size_or_sections, dim)
 
 # squeeze

--- a/mindtorch/torch/ops/creation.py
+++ b/mindtorch/torch/ops/creation.py
@@ -119,8 +119,7 @@ def empty(*size, dtype=None, device=None, requires_grad=False):
         size = size[0]
     if dtype is None:
         dtype = get_default_dtype()
-    out = CTensor(dtype, size)
-    out = mindspore.Tensor(out)
+    out = mindspore.mint.empty(size, dtype=dtype, device=device)
     if requires_grad:
         out.requires_grad = True
     return out

--- a/mindtorch/torch/ops/pointwise.py
+++ b/mindtorch/torch/ops/pointwise.py
@@ -234,7 +234,8 @@ has_exp = hasattr(mindspore.mint, 'exp')
 def exp(input, out=None):
     if use_pyboost() and has_exp:
         output = mindspore.mint.exp(input)
-    output = ops.exp(input)
+    else:
+        output = ops.exp(input)
     if out is not None:
         out.data = output
     else:


### PR DESCRIPTION
Test case in pipeline stage=2 with 8 devices

1. The op number of pytorch：
**Rank 0：5261**
**Rank 7：4781**

2. Before optimization, the op number of mindspore：
**Rank 0：5616**
**Rank 7：4958**

3. After optimization, the op number of mindspore：
**Rank 0：5232**
**Rank 7：4598**

4. end-to-end Improvement：
pytorch：**1.62s**
mindspore：**3.54s/step（0.46x PT）** -> **1.91-1.95s/step（0.83-0.85x PT）**